### PR TITLE
Implements infrastructure for customTimeouts

### DIFF
--- a/dao/server_dao.py
+++ b/dao/server_dao.py
@@ -13,7 +13,7 @@ class ServerDao:
 
   def get_server(self, server_id):
     c = self.conn.cursor()
-    c.execute('SELECT * FROM `server` WHERE server_id='+str(server_id))
+    c.execute('SELECT server_id, infracted_at, calledout_at, awake, timeout_duration_seconds FROM `server` WHERE server_id='+str(server_id))
 
     row = c.fetchone()
     if row is None:
@@ -23,15 +23,19 @@ class ServerDao:
       'server_id': row[0], 
       'infracted_at': datetime.datetime.strptime(row[1], "%Y-%m-%d %H:%M:%S"), 
       'calledout_at': datetime.datetime.strptime(row[2], "%Y-%m-%d %H:%M:%S"), 
-      'awake': row[3]
+      'awake': row[3],
+      'timeout_duration_seconds': row[4]
     }
     return server
 
   def insert_server(self, server_row):
     c = self.conn.cursor()
-    res = c.execute('INSERT OR REPLACE INTO `server` (server_id, infracted_at, calledout_at, awake) VALUES (?, ?, ?, ?)',
-            (server_row['server_id'], server_row['infracted_at'].strftime("%Y-%m-%d %H:%M:%S"),
-             server_row['calledout_at'].strftime("%Y-%m-%d %H:%M:%S"), int(server_row['awake'])))
+    res = c.execute('INSERT OR REPLACE INTO `server` (server_id, infracted_at, calledout_at, awake, timeout_duration_seconds) VALUES (?, ?, ?, ?, ?)',
+            (server_row['server_id'],
+             server_row['infracted_at'].strftime("%Y-%m-%d %H:%M:%S"),
+             server_row['calledout_at'].strftime("%Y-%m-%d %H:%M:%S"),
+             int(server_row['awake']),
+             server_row['timeout_duration_seconds']))
     self.conn.commit()
 
     return res

--- a/migrations/timeout-add.sql
+++ b/migrations/timeout-add.sql
@@ -1,0 +1,1 @@
+ALTER TABLE 'server' ADD COLUMN timeout_duration_seconds DEFAULT 1800;

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -11,13 +11,14 @@ class TestAwakeNoCooldownBot(unittest.TestCase):
             'server_id' : 1,
             'infracted_at': self.current_time - datetime.timedelta(minutes=30),
             'calledout_at': self.current_time - datetime.timedelta(minutes=30),
-            'awake' : True
+            'awake' : True,
+            'timeout_duration_seconds': 1800
         }
         self.server_dao = Mock(**{
             'get_server.return_value': self.current_server,
             'insert_server.return_value': None
         })
-        self.infringedString = "@test referenced the forbidden word, setting the counter back to 0. I'll wait a half hour before warning you again.\n The server went 30 minutes and 0 seconds without mentioning it."
+        self.infringedString = "@test referenced the forbidden word, setting the counter back to 0.\nI'll wait 30 minutes and 0 seconds before warning you again.\nThe server went 30 minutes and 0 seconds without mentioning the forbidden word."
 
     def test_handle_message__valid_post(self):
         message = Mock(**{
@@ -194,7 +195,8 @@ class TestAwakeCooldownBot(unittest.TestCase):
             'server_id' : 1,
             'infracted_at': self.current_time - datetime.timedelta(minutes=30),
             'calledout_at': self.current_time - datetime.timedelta(minutes=20),
-            'awake' : True
+            'awake' : True,
+            'timeout_duration_seconds': 1800
         }
         self.server_dao = Mock(**{
             'get_server.return_value': self.current_server,
@@ -223,7 +225,8 @@ class TestAsleepBot(unittest.TestCase):
             'server_id' : 1,
             'infracted_at': self.current_time - datetime.timedelta(minutes=30),
             'calledout_at': self.current_time - datetime.timedelta(minutes=40),
-            'awake' : False
+            'awake' : False,
+            'timeout_duration_seconds': 1800
         }
         self.server_dao = Mock(**{
             'get_server.return_value': self.current_server,
@@ -337,6 +340,11 @@ class testCommandParsingAdmin(unittest.TestCase):
         cmd = bot.parse_for_command(msg, self.author)
         self.assertEqual(cmd, bot.Commands.VTLAST)
 
+    def test_parse_for_command__VTCT_only(self):
+        msg = "!vtct"
+        cmd = bot.parse_for_command(msg, self.author)
+        self.assertEqual(cmd, bot.Commands.VTCT)
+
 
 class testCommandParsingNoAdmin(unittest.TestCase):
     def setUp(self):
@@ -383,3 +391,8 @@ class testCommandParsingNoAdmin(unittest.TestCase):
         msg = "!vtlast"
         cmd = bot.parse_for_command(msg, self.author)
         self.assertEqual(cmd, bot.Commands.VTLAST)
+
+    def test_parse_for_command__VTCT_only(self):
+        msg = "!vtct"
+        cmd = bot.parse_for_command(msg, self.author)
+        self.assertEqual(cmd, bot.Commands.VTCT)


### PR DESCRIPTION
Adds a new command, "!vtct" that returns the length of the currently
defined timeout, as well as how long it will be until the next alert may
be issued.

To this end, a new column has been added to the database which denotes
the length, in seconds, of that server's timeout length.

Still needs testing, but here it is for the sake of review