### PR TITLE
Discord API requests use Authorization header now

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -6,8 +6,8 @@ import config
 print('Hitting discord\'s API to determine how many shards are needed.')
 key = config.CLIENT_KEY
 
-url = 'https://discordapp.com/api/v6/gateway/bot?token=' + key
-response = requests.get(url)
+url = 'https://discordapp.com/api/v6/gateway/bot'
+response = requests.get(url, headers = {'Authorization': 'Bot ' + key})
 
 processes = []
 if (response.ok):
@@ -16,9 +16,6 @@ if (response.ok):
 	for x in range(0, shard_count):
 		processes.append(subprocess.Popen('./botLaunch.sh '+str(x)+' ' + str(shard_count), shell=True))
 	print("Launched processes")
-	with open("logs/pids.txt", "w") as target:
-		for process in processes:
-			target.write('{}\n'.format(process.pid))
 else:
 	print("Can't reach the Gateway endpoint. Giving up.")
 


### PR DESCRIPTION
Turns out, the reason the startup script wasn't working is that the API
requires an authorization header now, instead of attaching the token as
a param.