### PR TITLE
Updates Confusables to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ async-timeout==3.0.1
 attrs==19.3.0
 certifi==2019.9.11
 chardet==3.0.4
-confusables==1.1.0
+confusables==1.1.1
 discord.py==1.2.5
 idna==2.8
 idna-ssl==1.1.0


### PR DESCRIPTION
This should fix some issues with regex-meaningful characters in banned
words, like | and []