### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.swp
+*.conf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 logs/*.txt
 db/*
+*.conf

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.pyc
 logs/*.txt
 db/*
-*.conf
+environment.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ python:
 - '3.6'
 script:
 - python3 -m unittest discover
+env:
+- CLIENT_KEY=ASDFASDF API_BASE_URL=http://127.0.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT [ "python", "-u", "./startup.py"]	

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-ENTRYPOINT [ "python", "-u", "./startup.py"]	
+ENTRYPOINT [ "python", "-u", "./startup.py"]

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ bot:
 
 test:
 	python -m unittest discover
+
+tester:
+	docker run --entrypoint /bin/bash -it --env-file testenv.conf --mount src="$(pwd)",target=/usr/src/app,type=bind mathemagical/banned-word-bot

--- a/bot.py
+++ b/bot.py
@@ -2,11 +2,13 @@ from collections import defaultdict
 import datetime
 import discord
 import json
+import os
 
-from config import API_BASE_URL
 from serverobjects.server import DiscordServer
 from utils.time import parse_time, format_time, format_seconds
 from commands import TimerCommand, CooldownCommand, HelpCommand, SilenceCommand, AlertCommand, AddBanCommand, RemoveBanCommand, ChangeBanCommand, ChangeTimeCommand, NoCommand
+
+API_BASE_URL = os.environ["API_BASE_URL"]
 
 command_map = defaultdict(
     lambda: NoCommand,

--- a/botLaunch.sh
+++ b/botLaunch.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 while true; do
-	python 'main.py' $1 $2
+	python -u 'main.py' $1 $2
     echo "Bot instance " $1 " crashed.  Respawning.." >&2
     sleep 1
 done

--- a/config.py
+++ b/config.py
@@ -1,2 +1,0 @@
-API_BASE_URL = ''
-CLIENT_KEY = ''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  bot:
+    env_file: environment.conf
+    build: .
+  api:
+    build: ../bannedWordServer
+    env_file: ../bannedWordServer/envrionment.conf
+    ports:
+      - "5000:5000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,14 @@
-version: '3'
+version: '3.7'
 services:
   bot:
     env_file: environment.conf
     build: .
   api:
     build: ../bannedWordServer
-    env_file: ../bannedWordServer/envrionment.conf
+    env_file: ../bannedWordServer/environment.conf
     ports:
       - "5000:5000"
+    volumes:
+      - type: bind
+        source: ../bannedWordServer/bannedWordServer/vt.db
+        target: /usr/src/api/bannedWordServer/vt.db

--- a/main.py
+++ b/main.py
@@ -1,14 +1,14 @@
+import os
 import sys
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
-import config
 import bot
 
 def initialize_session():
     session = requests.Session()
-    session.headers.update({'Authorization': 'Bot ' + config.CLIENT_KEY})
+    session.headers.update({'Authorization': 'Bot ' + os.environ["CLIENT_KEY"]})
     retry = Retry(
         total=5,
         read=1,
@@ -21,4 +21,4 @@ def initialize_session():
     session.mount('https://', adapter)
     return session
 
-bot.run_bot(int(sys.argv[1]), int(sys.argv[2]), config.CLIENT_KEY, initialize_session())
+bot.run_bot(int(sys.argv[1]), int(sys.argv[2]), os.environ["CLIENT_KEY"], initialize_session())

--- a/serverobjects/ban.py
+++ b/serverobjects/ban.py
@@ -1,10 +1,12 @@
 from confusables import confusable_regex
 import datetime
 import json
+import os
 import re
 import requests
 
-from config import API_BASE_URL, CLIENT_KEY
+API_BASE_URL = os.environ["API_BASE_URL"]
+CLIENT_KEY = os.environ["CLIENT_KEY"]
 
 class BanInstance:
   def __init__(self, banJson, current_time, timeout_duration, session):

--- a/serverobjects/server.py
+++ b/serverobjects/server.py
@@ -1,8 +1,11 @@
 import requests
 import json
+import os
 
-from config import API_BASE_URL, CLIENT_KEY
 from serverobjects import BanInstance
+
+API_BASE_URL = os.environ["API_BASE_URL"]
+CLIENT_KEY = os.environ["CLIENT_KEY"]
 
 class DiscordServer:
 	def __init__(self, server_data, current_time, session):

--- a/startup.py
+++ b/startup.py
@@ -1,13 +1,11 @@
 import json
 import requests
 import subprocess
-import config
+import os
 
 print('Hitting discord\'s API to determine how many shards are needed.')
-key = config.CLIENT_KEY
-
 url = 'https://discordapp.com/api/v6/gateway/bot'
-response = requests.get(url, headers = {'Authorization': 'Bot ' + key})
+response = requests.get(url, headers = {'Authorization': 'Bot ' + os.environ["CLIENT_KEY"]})
 
 processes = []
 if (response.ok):
@@ -19,3 +17,4 @@ if (response.ok):
 else:
 	print("Can't reach the Gateway endpoint. Giving up.")
 
+exit_codes = [p.wait() for p in processes]

--- a/testenv.conf
+++ b/testenv.conf
@@ -1,0 +1,2 @@
+CLIENT_KEY=NoThanks
+API_BASE_URL=http://garb.age:5000

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -6,7 +6,6 @@ from types import MethodType
 import bot
 from commands import TimerCommand, CooldownCommand, HelpCommand, SilenceCommand, AlertCommand, ChangeBanCommand, AddBanCommand, RemoveBanCommand, ChangeTimeCommand, NoCommand
 from serverobjects import DiscordServer, BanInstance
-from config import API_BASE_URL
 
 @patch.object(DiscordServer, 'update_server_settings')
 @patch.object(BanInstance, 'send_infringing_message')


### PR DESCRIPTION
Takes a stab at dockerizing the bot. This involves a handful of connected developments:
1) The bot now relies on the local environment variables instead of parsing a config file
2) a tester make target has been added, to allow for entering a test-environment
3) a dockerfile and docker-compose file have been created to allow for local deployment, as well as the general creation of images.