### PR TITLE
Bot handles failure to set server params

### DIFF
--- a/commands/changetimecommand.py
+++ b/commands/changetimecommand.py
@@ -9,7 +9,9 @@ class ChangeTimeCommand(Command):
 		parsed_time = parse_time(message[8:])
 
 		if parsed_time >= 0:
-			current_server.set_timeout(parsed_time)
+			update_succeeded = current_server.set_timeout(parsed_time)
+			if not update_succeeded:
+				return "Sorry, something went wrong and I couldn't update the delay. Make sure the delay is under 100 million seconds (~3 years)"
 			formatted_time = format_seconds(parsed_time)
 			return "Cool, from now on I'll wait at least {} between alerts.".format(formatted_time)
 		else:

--- a/serverobjects/server.py
+++ b/serverobjects/server.py
@@ -34,6 +34,8 @@ class DiscordServer:
 			jData = json.loads(response.content)
 			self.awake = bool(jData['awake'])
 			self.timeout_duration_seconds = int(jData['timeout_duration_seconds'])
+			return True
+		return False
 
 	def ban_new_word(self, new_word):
 		response = self._session.post(

--- a/tests/commands/test_changetimecommand.py
+++ b/tests/commands/test_changetimecommand.py
@@ -74,6 +74,28 @@ class TestChangeTimeCommand(unittest.TestCase):
 		self.assertTrue(time_patch.called)
 
 	@patch('serverobjects.server.DiscordServer.set_timeout')
+	def test_execute__change_second_too_long(self, time_patch):
+		time_patch.return_value = False
+
+		message = Mock(**{
+      'server': Mock(**{
+        'id': 1
+      }),
+      'content': "!vtdelay 777777777777",
+      'author': Mock(**{
+        'id': 2,
+        'mention': "@test",
+        'bot': False
+      }),
+    })
+		server = DiscordServer(self.server_json, self.time, None)
+		retval = self.command.execute(server, self.time, message.content, message.author)
+		self.assertEqual(
+			retval,
+			"Sorry, something went wrong and I couldn't update the delay. Make sure the delay is under 100 million seconds (~3 years)"
+		)
+
+	@patch('serverobjects.server.DiscordServer.set_timeout')
 	def test_execute__change_extra_invalid(self, time_patch):
 		message = Mock(**{
       'server': Mock(**{


### PR DESCRIPTION
Now the bot will let the user know if it fails to update the delay,
this is prep for fixing the max delay.

closes #95 