### PR TITLE
Fixes the messaging for delay commands

### DIFF
--- a/serverobjects/server.py
+++ b/serverobjects/server.py
@@ -20,10 +20,10 @@ class DiscordServer:
 			self.banned_words.append(ban)
 
 	def set_awake(self, new_awake):
-		self.update_server_settings({'awake': new_awake})
+		return self.update_server_settings({'awake': new_awake})
 
 	def set_timeout(self, new_timeout):
-		self.update_server_settings({'timeout_duration_seconds': new_timeout})
+		return self.update_server_settings({'timeout_duration_seconds': new_timeout})
 
 	def update_server_settings(self, updated_params):
 		response = self._session.post(
@@ -34,8 +34,7 @@ class DiscordServer:
 			jData = json.loads(response.content)
 			self.awake = bool(jData['awake'])
 			self.timeout_duration_seconds = int(jData['timeout_duration_seconds'])
-			return True
-		return False
+		return response.ok
 
 	def ban_new_word(self, new_word):
 		response = self._session.post(

--- a/tests/commands/test_changetimecommand.py
+++ b/tests/commands/test_changetimecommand.py
@@ -37,7 +37,7 @@ class TestChangeTimeCommand(unittest.TestCase):
 		result = self.command.is_command_authorized(permissions)
 		self.assertTrue(result)
 
-	@patch('serverobjects.server.DiscordServer.set_timeout')
+	@patch('serverobjects.server.DiscordServer.update_server_settings')
 	def test_execute__change_full_time_valid(self, time_patch):
 		message = Mock(**{
       'server': Mock(**{
@@ -51,17 +51,21 @@ class TestChangeTimeCommand(unittest.TestCase):
       }),
     })
 		server = DiscordServer(self.server_json, self.time, None)
-		self.command.execute(server, self.time, message.content, message.author)
-		time_patch.assert_called_with(1+1*60+1*60*60)
+		retval = self.command.execute(server, self.time, message.content, message.author)
+		time_patch.assert_called_with({ 'timeout_duration_seconds': 1+1*60+1*60*60 })
+		self.assertEqual(
+			retval,
+			"Cool, from now on I'll wait at least 1 hour, 1 minute, and 1 second between alerts."
+		)
 		self.assertTrue(time_patch.called)
 
-	@patch('serverobjects.server.DiscordServer.set_timeout')
+	@patch('serverobjects.server.DiscordServer.update_server_settings')
 	def test_execute__change_second_time_valid(self, time_patch):
 		message = Mock(**{
       'server': Mock(**{
         'id': 1
       }),
-      'content': "!vtdelay 999",
+      'content': "!vtdelay 45",
       'author': Mock(**{
         'id': 2,
         'mention': "@test",
@@ -69,11 +73,15 @@ class TestChangeTimeCommand(unittest.TestCase):
       }),
     })
 		server = DiscordServer(self.server_json, self.time, None)
-		self.command.execute(server, self.time, message.content, message.author)
-		time_patch.assert_called_with(999)
+		retval = self.command.execute(server, self.time, message.content, message.author)
+		time_patch.assert_called_with({ 'timeout_duration_seconds': 45 })
+		self.assertEqual(
+			retval,
+			"Cool, from now on I'll wait at least 45 seconds between alerts."
+		)
 		self.assertTrue(time_patch.called)
 
-	@patch('serverobjects.server.DiscordServer.set_timeout')
+	@patch('serverobjects.server.DiscordServer.update_server_settings')
 	def test_execute__change_second_too_long(self, time_patch):
 		time_patch.return_value = False
 


### PR DESCRIPTION
Somewhat comically, a boolean value wasn't being returned all the
way through the chain, so it eventually became None, thus always falsey.
This has been fixed, with two tests modified to check at the right
level to prevent this in the future. More extensive testing might be
needed later.

Closes #99