### PR TITLE
Adds custom prefix command+handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,23 +6,24 @@ import os
 
 from serverobjects.server import DiscordServer
 from utils.time import parse_time, format_time, format_seconds
-from commands import TimerCommand, CooldownCommand, HelpCommand, SilenceCommand, AlertCommand, AddBanCommand, RemoveBanCommand, ChangeBanCommand, ChangeTimeCommand, ListRecordCommand, NoCommand
+from commands import TimerCommand, CooldownCommand, HelpCommand, SilenceCommand, AlertCommand, AddBanCommand, RemoveBanCommand, ChangeBanCommand, ChangeTimeCommand, ChangePrefixCommand, ListRecordCommand, NoCommand
 
 API_BASE_URL = os.environ["API_BASE_URL"]
 
 command_map = defaultdict(
     lambda: NoCommand,
     {
-        '!vtsilence': SilenceCommand,
-        '!vtalert': AlertCommand,
-        '!vtdelay': ChangeTimeCommand,
-        '!vtban': AddBanCommand,
-        '!vtswapban': ChangeBanCommand,
-        '!vtunban': RemoveBanCommand,
-        '!vthelp': HelpCommand,
-        '!vtct': CooldownCommand,
-        '!vtr': ListRecordCommand,
-        '!vt': TimerCommand
+        'silence': SilenceCommand,
+        'alert': AlertCommand,
+        'delay': ChangeTimeCommand,
+        'prefix': ChangePrefixCommand,
+        'ban': AddBanCommand,
+        'swapban': ChangeBanCommand,
+        'unban': RemoveBanCommand,
+        'help': HelpCommand,
+        'ct': CooldownCommand,
+        'r': ListRecordCommand,
+        '': TimerCommand
     })
 
 callout_phrase = (
@@ -69,7 +70,13 @@ def handle_message(message, current_time, session):
     if (hasattr(message.author, 'permissions_in')):
         permissions = message.author.permissions_in(message.channel)
 
-    found_command = command_map[message.content.split(' ')[0]]()
+    found_command = NoCommand()
+    first_word = message.content.split(' ')[0]
+    if first_word.startswith(current_server.prefix):
+        found_command = command_map[first_word[len(current_server.prefix):]]()
+    if first_word.startswith('!vthelp'):
+        found_command = HelpCommand()
+
     if (not found_command.is_command_authorized(permissions)):
         msg_to_send = "Sorry, you don't have permissions for this."
     else:

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -8,4 +8,5 @@ from .addbancommand import AddBanCommand
 from .changebancommand import ChangeBanCommand
 from .removebancommand import RemoveBanCommand
 from .changetimecommand import ChangeTimeCommand
+from .changeprefixcommand import ChangePrefixCommand
 from .nocommand import NoCommand

--- a/commands/changeprefixcommand.py
+++ b/commands/changeprefixcommand.py
@@ -1,0 +1,17 @@
+from commands.command import Command
+
+class ChangePrefixCommand(Command):
+	def is_command_authorized(self, permissions=None):
+		return permissions and permissions.administrator
+
+	def execute(self, current_server, current_time, message, author):
+		new_prefix = message.lstrip().split(' ')[1]
+		print(new_prefix)
+		print("!!!!!!!!!!!!!")
+		if len(new_prefix) > 0 and len(new_prefix) <= 10:
+			update_succeeded = current_server.set_prefix(new_prefix)
+			if not update_succeeded:
+				return "Sorry, something went wrong and I couldn't update the prefix."
+			return "Cool, from now on you'll need to start a message with '{}' for me to treat it as a command.".format(new_prefix)
+		else:
+			return "Sorry, I don't understand that formatting. I was expecting a new prefix between 1 and 10 characters long."

--- a/commands/changetimecommand.py
+++ b/commands/changetimecommand.py
@@ -6,7 +6,11 @@ class ChangeTimeCommand(Command):
 		return permissions and permissions.administrator
 
 	def execute(self, current_server, current_time, message, author):
-		parsed_time = parse_time(message[8:])
+		strings = message.lstrip().split(' ', 1)
+		if len(strings) < 2:
+			return "Sorry, I don't understand that formatting. I was expecting something like '!vtct hh:mm:ss'"
+
+		parsed_time = parse_time(strings[1])
 
 		if parsed_time >= 0:
 			update_succeeded = current_server.set_timeout(parsed_time)

--- a/commands/helpcommand.py
+++ b/commands/helpcommand.py
@@ -1,8 +1,8 @@
 from commands.command import Command
 
 class HelpCommand(Command):
-	def execute(self, current_server=None, current_time=None, message=None, author=None):
-		msg_to_send = "You can ask me how long we've made it with '!vt'.\n"
-		msg_to_send += "You can learn how long my timeout is set for, and when I can issue another warning with '!vtct'.\n"
+	def execute(self, current_server, current_time, message, author):
+		msg_to_send = "You can ask me how long we've made it with '{}'.\n".format(current_server.prefix)
+		msg_to_send += "You can learn how long my timeout is set for, and when I can issue another warning with '{}ct'.\n".format(current_server.prefix)
 		msg_to_send += "For other commands, server management, and general help, please check either the documentation (https://bwbdiscord.gitbook.io/banned-word-tracker/) or the support server (https://discord.gg/W7mrxRd)."
 		return msg_to_send

--- a/serverobjects/server.py
+++ b/serverobjects/server.py
@@ -14,6 +14,7 @@ class DiscordServer:
 		self.server_id = int(server_data['server_id'])
 		self.awake = bool(server_data['awake'])
 		self.timeout_duration_seconds = int(server_data['timeout_duration_seconds'])
+		self.prefix = server_data['prefix']
 		self.banned_words = []
 		for word in server_data['banned_words']:
 			ban = BanInstance(word, self.current_time, self.timeout_duration_seconds, self._session)
@@ -25,6 +26,9 @@ class DiscordServer:
 	def set_timeout(self, new_timeout):
 		return self.update_server_settings({'timeout_duration_seconds': new_timeout})
 
+	def set_prefix(self, new_prefix):
+		return self.update_server_settings({'prefix': new_prefix})
+
 	def update_server_settings(self, updated_params):
 		response = self._session.post(
 			API_BASE_URL + 'v1/servers/' + str(self.server_id), 
@@ -34,6 +38,7 @@ class DiscordServer:
 			jData = json.loads(response.content)
 			self.awake = bool(jData['awake'])
 			self.timeout_duration_seconds = int(jData['timeout_duration_seconds'])
+			self.prefix = jData['prefix']
 		return response.ok
 
 	def ban_new_word(self, new_word):

--- a/tests/commands/test_addbancommand.py
+++ b/tests/commands/test_addbancommand.py
@@ -31,6 +31,7 @@ class TestAddBanCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,
@@ -66,6 +67,7 @@ class TestAddBanCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,

--- a/tests/commands/test_alertcommand.py
+++ b/tests/commands/test_alertcommand.py
@@ -36,6 +36,7 @@ class TestAlertCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : False,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,

--- a/tests/commands/test_changebancommand.py
+++ b/tests/commands/test_changebancommand.py
@@ -31,6 +31,7 @@ class TestChangeBanCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,
@@ -66,6 +67,7 @@ class TestChangeBanCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,
@@ -101,6 +103,7 @@ class TestChangeBanCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,

--- a/tests/commands/test_changetimecommand.py
+++ b/tests/commands/test_changetimecommand.py
@@ -14,6 +14,7 @@ class TestChangeTimeCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,

--- a/tests/commands/test_cooldowncommand.py
+++ b/tests/commands/test_cooldowncommand.py
@@ -30,6 +30,7 @@ class TestCooldownCommand(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -54,6 +55,7 @@ class TestCooldownCommand(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -77,6 +79,7 @@ class TestCooldownCommand(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -113,6 +116,7 @@ class TestCooldownCommand(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -152,6 +156,7 @@ class TestCooldownCommand(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,

--- a/tests/commands/test_listrecordcommand.py
+++ b/tests/commands/test_listrecordcommand.py
@@ -30,6 +30,7 @@ class TestCooldownCommand(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -53,6 +54,7 @@ class TestCooldownCommand(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -76,6 +78,7 @@ class TestCooldownCommand(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -111,6 +114,7 @@ class TestCooldownCommand(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -148,6 +152,7 @@ class TestCooldownCommand(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,

--- a/tests/commands/test_removebancommand.py
+++ b/tests/commands/test_removebancommand.py
@@ -31,6 +31,7 @@ class TestRemoveBanCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,
@@ -77,6 +78,7 @@ class TestRemoveBanCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,
@@ -111,6 +113,7 @@ class TestRemoveBanCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,

--- a/tests/commands/test_silencecommand.py
+++ b/tests/commands/test_silencecommand.py
@@ -36,6 +36,7 @@ class TestSilenceCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,

--- a/tests/commands/test_timercommand.py
+++ b/tests/commands/test_timercommand.py
@@ -29,6 +29,7 @@ class TestTimerCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,
@@ -52,6 +53,7 @@ class TestTimerCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,
@@ -87,6 +89,7 @@ class TestTimerCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,
@@ -124,6 +127,7 @@ class TestTimerCommand(unittest.TestCase):
 			'server_id' : 1,
 			'awake' : True,
 			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
 			'banned_words': [{
 				'rowid': 1,
 				'server_id': 1,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -15,6 +15,7 @@ class TestAwakeNoCooldownBot(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -250,6 +251,7 @@ class TestAwakeCooldownBot(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -292,6 +294,7 @@ class TestAsleepBot(unittest.TestCase):
             'server_id' : 1,
             'awake' : False,
             'timeout_duration_seconds': 1800,
+            'prefix': '!vt',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -332,6 +335,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server_id' : 1,
             'awake' : True,
             'timeout_duration_seconds': 1800,
+            'prefix': '!bad',
             'banned_words': [{
                 'rowid': 1,
                 'server_id': 1,
@@ -367,12 +371,26 @@ class TestBotCallsCommands(unittest.TestCase):
 
     @patch('bot.fetch_server_from_api', side_effect=simple_server)
     @patch.object(NoCommand, 'execute')
-    def test_handle_message__no_command(self, noMock, sMock):
+    def test_handle_message__not_command(self, noMock, sMock):
         message = Mock(**{
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vttest",
+            'content': "!badtest",
+            'author': self.nonadmin,
+        })
+
+        message_to_send = bot.handle_message(message, self.current_time, None)
+        self.assertTrue(noMock.called)
+
+    @patch('bot.fetch_server_from_api', side_effect=simple_server)
+    @patch.object(NoCommand, 'execute')
+    def test_handle_message__bad_prefix(self, noMock, sMock):
+        message = Mock(**{
+            'server': Mock(**{
+                'id': 1
+            }),
+            'content': "!vt",
             'author': self.nonadmin,
         })
 
@@ -386,7 +404,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vt",
+            'content': "!bad",
             'author': self.nonadmin,
         })
 
@@ -400,7 +418,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vtr",
+            'content': "!badr",
             'author': self.nonadmin,
         })
 
@@ -414,7 +432,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vt test",
+            'content': "!bad test",
             'author': self.nonadmin,
         })
 
@@ -428,7 +446,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vtdelay 1",
+            'content': "!baddelay 1",
             'author': self.nonadmin,
         })
 
@@ -442,7 +460,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vtdelay 1",
+            'content': "!baddelay 1",
             'author': self.admin,
         })
 
@@ -456,7 +474,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vtban 1",
+            'content': "!badban 1",
             'author': self.admin,
         })
 
@@ -470,7 +488,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vtunban 1",
+            'content': "!badunban 1",
             'author': self.admin,
         })
 
@@ -484,7 +502,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vtct",
+            'content': "!badct",
             'author': self.admin,
         })
 
@@ -493,12 +511,26 @@ class TestBotCallsCommands(unittest.TestCase):
 
     @patch('bot.fetch_server_from_api', side_effect=simple_server)
     @patch.object(HelpCommand, 'execute')
-    def test_handle_message__VT_help(self, helpMock, sMock):
+    def test_handle_message__help_backup(self, helpMock, sMock):
         message = Mock(**{
             'server': Mock(**{
                 'id': 1
             }),
             'content': "!vthelp",
+            'author': self.admin,
+        })
+
+        message_to_send = bot.handle_message(message, self.current_time, None)
+        self.assertTrue(helpMock.called)
+
+    @patch('bot.fetch_server_from_api', side_effect=simple_server)
+    @patch.object(HelpCommand, 'execute')
+    def test_handle_message__VT_help(self, helpMock, sMock):
+        message = Mock(**{
+            'server': Mock(**{
+                'id': 1
+            }),
+            'content': "!badhelp",
             'author': self.admin,
         })
 
@@ -512,7 +544,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vtalert",
+            'content': "!badalert",
             'author': self.admin,
         })
 
@@ -526,7 +558,7 @@ class TestBotCallsCommands(unittest.TestCase):
             'server': Mock(**{
                 'id': 1
             }),
-            'content': "!vtsilence",
+            'content': "!badsilence",
             'author': self.admin,
         })
 


### PR DESCRIPTION
Now that the backend lets us specify a custom prefix,
we've gotta have the front-end actually make use of it.

For safety, "!vthelp" works regardless of the current prefix.