### PR TITLE
Adds tests+fix for prefix bug

### DIFF
--- a/commands/changeprefixcommand.py
+++ b/commands/changeprefixcommand.py
@@ -5,9 +5,11 @@ class ChangePrefixCommand(Command):
 		return permissions and permissions.administrator
 
 	def execute(self, current_server, current_time, message, author):
-		new_prefix = message.lstrip().split(' ')[1]
-		print(new_prefix)
-		print("!!!!!!!!!!!!!")
+		words = message.lstrip().split(' ')
+		if len(words) < 2:
+			return "Sorry, I don't understand that formatting. I was expecting a new prefix between 1 and 10 characters long."
+
+		new_prefix = words[1]
 		if len(new_prefix) > 0 and len(new_prefix) <= 10:
 			update_succeeded = current_server.set_prefix(new_prefix)
 			if not update_succeeded:

--- a/tests/commands/test_changeprefixcommand.py
+++ b/tests/commands/test_changeprefixcommand.py
@@ -1,0 +1,104 @@
+import unittest
+from unittest.mock import patch, Mock
+import discord
+import datetime
+
+from commands import ChangePrefixCommand
+from serverobjects.server import DiscordServer
+
+class TestChangePrefixCommand(unittest.TestCase):
+	def setUp(self):
+		self.command = ChangePrefixCommand()
+		self.time = datetime.datetime.now()
+		self.server_json = {
+			'server_id' : 1,
+			'awake' : True,
+			'timeout_duration_seconds': 1800,
+			'prefix': '!vt',
+			'banned_words': [{
+				'rowid': 1,
+				'server_id': 1,
+				'banned_word': 'vore',
+				'infracted_at': (self.time - datetime.timedelta(minutes=20)).strftime("%Y-%m-%d %H:%M:%S"),
+				'calledout_at': (self.time - datetime.timedelta(minutes=20)).strftime("%Y-%m-%d %H:%M:%S"),
+        'record': {
+            'record_seconds': 2400,
+            'infraction_count': 0
+        }
+			}]
+		}
+
+	def test_is_command_authorized__no_permissions_disallowed(self):
+		result = self.command.is_command_authorized()
+		self.assertFalse(result)
+
+	def test_is_command_authorized__non_admin_disallowed(self):
+		permissions = discord.Permissions()
+		result = self.command.is_command_authorized(permissions)
+		self.assertFalse(result)
+
+	def test_is_command_authorized__admin_allowed(self):
+		permissions = discord.Permissions.all()
+		result = self.command.is_command_authorized(permissions)
+		self.assertTrue(result)
+
+	@patch('serverobjects.server.DiscordServer.update_server_settings')
+	def test_execute__change_full_time_valid(self, prefix_patch):
+		message = Mock(**{
+      'server': Mock(**{
+        'id': 1
+      }),
+      'content': "!vtprefix !testin",
+      'author': Mock(**{
+        'id': 2,
+        'mention': "@test",
+        'bot': False
+      }),
+    })
+		server = DiscordServer(self.server_json, self.time, None)
+		retval = self.command.execute(server, self.time, message.content, message.author)
+		prefix_patch.assert_called_with({ 'prefix': '!testin' })
+		self.assertEqual(
+			retval,
+			"Cool, from now on you'll need to start a message with '!testin' for me to treat it as a command."
+		)
+		self.assertTrue(prefix_patch.called)
+
+	@patch('serverobjects.server.DiscordServer.update_server_settings')
+	def test_execute__change_prefix_too_long(self, prefix_patch):
+		prefix_patch.return_value = False
+
+		message = Mock(**{
+      'server': Mock(**{
+        'id': 1
+      }),
+      'content': "!vtprefix asdfasdfasdf",
+      'author': Mock(**{
+        'id': 2,
+        'mention': "@test",
+        'bot': False
+      }),
+    })
+		server = DiscordServer(self.server_json, self.time, None)
+		retval = self.command.execute(server, self.time, message.content, message.author)
+		self.assertEqual(
+			retval,
+			"Sorry, I don't understand that formatting. I was expecting a new prefix between 1 and 10 characters long."
+		)
+
+	@patch('serverobjects.server.DiscordServer.update_server_settings')
+	def test_execute__change_no_time_invalid(self, prefix_patch):
+		message = Mock(**{
+      'server': Mock(**{
+        'id': 1
+      }),
+      'content': "!vtprefix",
+      'author': Mock(**{
+        'id': 2,
+        'mention': "@test",
+        'bot': False
+      }),
+    })
+		server = DiscordServer(self.server_json, self.time, None)
+		self.command.execute(server, self.time, message.content, message.author)
+		self.assertFalse(prefix_patch.called)


### PR DESCRIPTION
Whoops, turns out I completely forgot to test this command,
and also left an issue in that would throw an error if one
didn't submit any new prefix "!vtprefix     " for example.